### PR TITLE
Cache computed values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.keykatyu.mctranslation</groupId>
     <artifactId>MCTranslationLib</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <description>A Java Spigot library for translating Minecraft elements using their translation key</description>
 
     <properties>

--- a/src/main/java/fr/keykatyu/mctranslation/api/TranslationsCache.java
+++ b/src/main/java/fr/keykatyu/mctranslation/api/TranslationsCache.java
@@ -1,0 +1,44 @@
+package fr.keykatyu.mctranslation.api;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A simple cache to store loaded translation JSONs
+ */
+public class TranslationsCache {
+
+  private final Map<Language, JsonObject> cachedJsons = new HashMap<>();
+
+  /**
+   * Test if a language has been cached.
+   * @param language The language to test.
+   * @return The JSON object.
+   */
+  public boolean has(Language language) {
+      return cachedJsons.containsKey(language);
+  }
+
+  /**
+   * Get a cached JSON object for a language.
+   * @param language The language to get.
+   * @param key The key to get.
+   * @return The JSON element. Or {@code null} if not found.
+   */
+  public JsonElement get(Language language, String key) {
+    return cachedJsons.get(language).get(key);
+  }
+
+  /**
+   * Cache a JSON object for a language.
+   * @param language The language to cache.
+   * @param translatorObj The JSON object to cache.
+   */
+  public void cache(Language language, JsonObject translatorObj) {
+    cachedJsons.put(language, translatorObj);
+  }
+
+}


### PR DESCRIPTION
# Description

Right now, plugin is doing I/O on `every` request. This can become quite slow when a lot of them are required.

This PR allows MCTranslationLib to cache values read from disk. It is now more efficient at handling large amounts of translations.